### PR TITLE
Update package definition

### DIFF
--- a/ax/ax.go
+++ b/ax/ax.go
@@ -4,9 +4,10 @@
 package ax
 
 import (
-	"github.com/irifrance/gini/inter"
-	"github.com/irifrance/gini/z"
 	"time"
+
+	"github.com/operator-framework/gini/inter"
+	"github.com/operator-framework/gini/z"
 )
 
 // Interface T describes an assumptions exchanger (ax).

--- a/ax/ax_test.go
+++ b/ax/ax_test.go
@@ -5,13 +5,14 @@ package ax
 
 import (
 	"fmt"
-	"github.com/irifrance/gini"
-	"github.com/irifrance/gini/gen"
-	"github.com/irifrance/gini/z"
 	"log"
 	"math/rand"
 	"testing"
 	"time"
+
+	"github.com/operator-framework/gini"
+	"github.com/operator-framework/gini/gen"
+	"github.com/operator-framework/gini/z"
 )
 
 func ExampleNewT() {

--- a/ax/req.go
+++ b/ax/req.go
@@ -5,9 +5,10 @@ package ax
 
 import (
 	"fmt"
-	"github.com/irifrance/gini/z"
 	"sync"
 	"time"
+
+	"github.com/operator-framework/gini/z"
 )
 
 // Type ReqFlag describes options for submitting requests

--- a/ax/resp.go
+++ b/ax/resp.go
@@ -4,8 +4,9 @@
 package ax
 
 import (
-	"github.com/irifrance/gini/z"
 	"time"
+
+	"github.com/operator-framework/gini/z"
 )
 
 // Type Response describes the result of an ax Request.

--- a/cmd/bench/bench.go
+++ b/cmd/bench/bench.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/irifrance/gini/bench"
+	"github.com/operator-framework/gini/bench"
 )
 
 var selFlags = flag.NewFlagSet("sel", flag.ExitOnError)

--- a/cmd/crispd/crispd.go
+++ b/cmd/crispd/crispd.go
@@ -6,10 +6,11 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/irifrance/gini/crisp"
 	"log"
 	"os"
 	"path/filepath"
+
+	"github.com/operator-framework/gini/crisp"
 )
 
 var CrispD *crisp.Server

--- a/cmd/gini/icnf.go
+++ b/cmd/gini/icnf.go
@@ -6,14 +6,15 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/irifrance/gini"
-	"github.com/irifrance/gini/ax"
-	"github.com/irifrance/gini/dimacs"
-	"github.com/irifrance/gini/z"
 	"io"
 	"log"
 	"runtime"
 	"time"
+
+	"github.com/operator-framework/gini"
+	"github.com/operator-framework/gini/ax"
+	"github.com/operator-framework/gini/dimacs"
+	"github.com/operator-framework/gini/z"
 )
 
 var useAx = flag.Bool("ax", false, "run the assumption exchanger for icnf inputs")

--- a/cmd/gini/main.go
+++ b/cmd/gini/main.go
@@ -18,9 +18,9 @@ import (
 	"strings"
 	"time"
 
-	proto "github.com/irifrance/gini/crisp"
-	"github.com/irifrance/gini/internal/xo"
-	"github.com/irifrance/gini/z"
+	proto "github.com/operator-framework/gini/crisp"
+	"github.com/operator-framework/gini/internal/xo"
+	"github.com/operator-framework/gini/z"
 )
 
 var pprofAddr = flag.String("pprof", "", "address to serve http profile (eg :6060)")

--- a/crisp/client.go
+++ b/crisp/client.go
@@ -5,13 +5,14 @@ package crisp
 
 import (
 	"fmt"
-	"github.com/irifrance/gini/dimacs"
-	gnet "github.com/irifrance/gini/inter/net"
-	"github.com/irifrance/gini/internal/xo"
-	"github.com/irifrance/gini/z"
 	"io"
 	"log"
 	"net"
+
+	"github.com/operator-framework/gini/dimacs"
+	gnet "github.com/operator-framework/gini/inter/net"
+	"github.com/operator-framework/gini/internal/xo"
+	"github.com/operator-framework/gini/z"
 )
 
 // Type Client is a concrete Solver which communicates using the gini sat protocol.

--- a/crisp/client_test.go
+++ b/crisp/client_test.go
@@ -4,8 +4,9 @@
 package crisp
 
 import (
-	"github.com/irifrance/gini/inter/net"
 	"testing"
+
+	"github.com/operator-framework/gini/inter/net"
 )
 
 func TestClient(t *testing.T) {

--- a/crisp/handler.go
+++ b/crisp/handler.go
@@ -5,12 +5,13 @@ package crisp
 
 import (
 	"fmt"
-	"github.com/irifrance/gini"
-	"github.com/irifrance/gini/inter"
-	"github.com/irifrance/gini/z"
 	"log"
 	"net"
 	"os"
+
+	"github.com/operator-framework/gini"
+	"github.com/operator-framework/gini/inter"
+	"github.com/operator-framework/gini/z"
 )
 
 var trace = false

--- a/crisp/server_test.go
+++ b/crisp/server_test.go
@@ -5,15 +5,16 @@ package crisp
 
 import (
 	"fmt"
-	"github.com/irifrance/gini/gen"
-	"github.com/irifrance/gini/internal/xo"
-	"github.com/irifrance/gini/z"
 	"log"
 	"math/rand"
 	"os"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/operator-framework/gini/gen"
+	"github.com/operator-framework/gini/internal/xo"
+	"github.com/operator-framework/gini/z"
 )
 
 func init() {

--- a/crisp/vu32io.go
+++ b/crisp/vu32io.go
@@ -5,8 +5,9 @@ package crisp
 
 import (
 	"fmt"
-	"github.com/irifrance/gini/z"
 	"io"
+
+	"github.com/operator-framework/gini/z"
 )
 
 // This file implements varint encoding/decoding + buffered io

--- a/dimacs/cnf.go
+++ b/dimacs/cnf.go
@@ -6,8 +6,9 @@ package dimacs
 import (
 	"bufio"
 	"fmt"
-	"github.com/irifrance/gini/z"
 	"io"
+
+	"github.com/operator-framework/gini/z"
 )
 
 // Type Reader holds info for reading dimacs formatted intput.

--- a/dimacs/cnf_test.go
+++ b/dimacs/cnf_test.go
@@ -5,8 +5,9 @@ package dimacs
 
 import (
 	"bytes"
-	"github.com/irifrance/gini/z"
 	"testing"
+
+	"github.com/operator-framework/gini/z"
 )
 
 type dimacsTestData struct {

--- a/dimacs/icnf.go
+++ b/dimacs/icnf.go
@@ -6,8 +6,9 @@ package dimacs
 import (
 	"bufio"
 	"fmt"
-	"github.com/irifrance/gini/z"
 	"io"
+
+	"github.com/operator-framework/gini/z"
 )
 
 type iCnfReader struct {

--- a/dimacs/icnf_test.go
+++ b/dimacs/icnf_test.go
@@ -6,8 +6,9 @@ package dimacs
 import (
 	"bytes"
 	"fmt"
-	"github.com/irifrance/gini/z"
 	"testing"
+
+	"github.com/operator-framework/gini/z"
 )
 
 var iCnf = `p inccnf

--- a/dimacs/lit.go
+++ b/dimacs/lit.go
@@ -5,7 +5,8 @@ package dimacs
 
 import (
 	"bufio"
-	"github.com/irifrance/gini/z"
+
+	"github.com/operator-framework/gini/z"
 )
 
 func readLit(r *bufio.Reader) (m z.Lit, e error) {

--- a/dimacs/vis.go
+++ b/dimacs/vis.go
@@ -3,7 +3,7 @@
 
 package dimacs
 
-import "github.com/irifrance/gini/z"
+import "github.com/operator-framework/gini/z"
 
 // Type Vis provides a visitor interface to reading dimacs files.
 //

--- a/gen/color.go
+++ b/gen/color.go
@@ -6,8 +6,8 @@ package gen
 import (
 	"math/rand"
 
-	"github.com/irifrance/gini/inter"
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/inter"
+	"github.com/operator-framework/gini/z"
 )
 
 // RandColor creates a formula asking if a random

--- a/gen/color_test.go
+++ b/gen/color_test.go
@@ -4,8 +4,9 @@
 package gen_test
 
 import (
-	"github.com/irifrance/gini/gen"
 	"testing"
+
+	"github.com/operator-framework/gini/gen"
 )
 
 func TestRandGraph(t *testing.T) {

--- a/gen/cubes.go
+++ b/gen/cubes.go
@@ -6,7 +6,7 @@ package gen
 import (
 	"math/rand"
 
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/z"
 )
 
 type RandCuber interface {

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -7,8 +7,8 @@ import (
 	"math/rand"
 	"sync"
 
-	"github.com/irifrance/gini/inter"
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/inter"
+	"github.com/operator-framework/gini/z"
 )
 
 /// make the rng seedable

--- a/gen/pt.go
+++ b/gen/pt.go
@@ -6,8 +6,8 @@ package gen
 import (
 	"sort"
 
-	"github.com/irifrance/gini/inter"
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/inter"
+	"github.com/operator-framework/gini/z"
 )
 
 // PartVar returns a variable if element i is in partition k

--- a/gen/pt_test.go
+++ b/gen/pt_test.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"testing"
 
-	"github.com/irifrance/gini"
+	"github.com/operator-framework/gini"
 )
 
 func TestPart(t *testing.T) {

--- a/gen/rands.go
+++ b/gen/rands.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/irifrance/gini/inter"
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/inter"
+	"github.com/operator-framework/gini/z"
 )
 
 // RandS creates an inter.S which just returns  result to Solve() within a

--- a/gen/rands_test.go
+++ b/gen/rands_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/z"
 )
 
 func TestRands(t *testing.T) {

--- a/gini.go
+++ b/gini.go
@@ -7,10 +7,10 @@ import (
 	"io"
 	"time"
 
-	"github.com/irifrance/gini/dimacs"
-	"github.com/irifrance/gini/inter"
-	"github.com/irifrance/gini/internal/xo"
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/dimacs"
+	"github.com/operator-framework/gini/inter"
+	"github.com/operator-framework/gini/internal/xo"
+	"github.com/operator-framework/gini/z"
 )
 
 // Gini is a concrete implementation of solver

--- a/gini_test.go
+++ b/gini_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/irifrance/gini/gen"
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/gen"
+	"github.com/operator-framework/gini/z"
 )
 
 func TestGiniTrivUnsat(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/irifrance/gini
+module github.com/operator-framework/gini

--- a/inter/net/net.go
+++ b/inter/net/net.go
@@ -4,8 +4,8 @@
 package net
 
 import (
-	"github.com/irifrance/gini/inter"
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/inter"
+	"github.com/operator-framework/gini/z"
 )
 
 type Solvable interface {

--- a/inter/net/netsolve.go
+++ b/inter/net/netsolve.go
@@ -4,8 +4,9 @@
 package net
 
 import (
-	"github.com/irifrance/gini/inter"
 	"time"
+
+	"github.com/operator-framework/gini/inter"
 )
 
 // Interface NetSolve represents an asynchronous  connection to a call to solve

--- a/inter/s.go
+++ b/inter/s.go
@@ -6,7 +6,7 @@ package inter
 import (
 	"time"
 
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/z"
 )
 
 // Interface Solveable encapsulates a decision

--- a/internal/xo/active.go
+++ b/internal/xo/active.go
@@ -1,7 +1,7 @@
 package xo
 
 import (
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/z"
 )
 
 type Active struct {

--- a/internal/xo/active_test.go
+++ b/internal/xo/active_test.go
@@ -4,7 +4,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/z"
 )
 
 func TestActive3(t *testing.T) {

--- a/internal/xo/cdat.go
+++ b/internal/xo/cdat.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"math"
 
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/z"
 )
 
 // Type CDat: basic operations for storing all the literals (and Chds) in a CNF

--- a/internal/xo/cdat_test.go
+++ b/internal/xo/cdat_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/z"
 )
 
 var cnf = [][]z.Lit{

--- a/internal/xo/cdb.go
+++ b/internal/xo/cdb.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/z"
 )
 
 // Type Cdb is the main interface to clauses.

--- a/internal/xo/cdb_test.go
+++ b/internal/xo/cdb_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/z"
 )
 
 var cnfDat = [...][]z.Lit{

--- a/internal/xo/cgc.go
+++ b/internal/xo/cgc.go
@@ -6,7 +6,7 @@ package xo
 import (
 	"sort"
 
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/z"
 )
 
 // Type Cgc encapsulates clause compaction/garbage collection.

--- a/internal/xo/cgc_test.go
+++ b/internal/xo/cgc_test.go
@@ -5,10 +5,11 @@ package xo
 
 import (
 	"fmt"
-	"github.com/irifrance/gini/z"
+	"math/rand"
 	"testing"
+
+	"github.com/operator-framework/gini/z"
 )
-import "math/rand"
 
 // nb var cnfDat from clauses_test.go
 

--- a/internal/xo/cloc.go
+++ b/internal/xo/cloc.go
@@ -3,7 +3,7 @@
 
 package xo
 
-import "github.com/irifrance/gini/z"
+import "github.com/operator-framework/gini/z"
 
 const (
 	CNull z.C = 0

--- a/internal/xo/ctl.go
+++ b/internal/xo/ctl.go
@@ -4,9 +4,10 @@
 package xo
 
 import (
-	"github.com/irifrance/gini/z"
 	"sync"
 	"time"
+
+	"github.com/operator-framework/gini/z"
 )
 
 // Type Ctl encapsulates low level asynchronous control

--- a/internal/xo/ctl_test.go
+++ b/internal/xo/ctl_test.go
@@ -5,11 +5,12 @@ package xo
 
 import (
 	"fmt"
-	"github.com/irifrance/gini/gen"
 	"log"
 	"math/rand"
 	"testing"
 	"time"
+
+	"github.com/operator-framework/gini/gen"
 )
 
 func TestSolveTest(t *testing.T) {

--- a/internal/xo/derive.go
+++ b/internal/xo/derive.go
@@ -6,7 +6,7 @@ package xo
 import (
 	"fmt"
 
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/z"
 )
 
 type Deriver struct {

--- a/internal/xo/dimacs.go
+++ b/internal/xo/dimacs.go
@@ -3,7 +3,7 @@
 
 package xo
 
-import "github.com/irifrance/gini/z"
+import "github.com/operator-framework/gini/z"
 
 // Type DimacsVis implements dimacs.Vis for constructing
 // solvers from dimacs cnf files.

--- a/internal/xo/guess.go
+++ b/internal/xo/guess.go
@@ -6,7 +6,7 @@ package xo
 import (
 	"math"
 
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/z"
 )
 
 const (

--- a/internal/xo/guess_test.go
+++ b/internal/xo/guess_test.go
@@ -4,8 +4,9 @@
 package xo
 
 import (
-	"github.com/irifrance/gini/z"
 	"testing"
+
+	"github.com/operator-framework/gini/z"
 )
 
 func TestGuess(t *testing.T) {

--- a/internal/xo/phases.go
+++ b/internal/xo/phases.go
@@ -1,6 +1,6 @@
 package xo
 
-import "github.com/irifrance/gini/z"
+import "github.com/operator-framework/gini/z"
 
 type phases z.Var
 

--- a/internal/xo/s.go
+++ b/internal/xo/s.go
@@ -11,9 +11,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/irifrance/gini/dimacs"
-	"github.com/irifrance/gini/inter"
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/dimacs"
+	"github.com/operator-framework/gini/inter"
+	"github.com/operator-framework/gini/z"
 )
 
 const (

--- a/internal/xo/s_test.go
+++ b/internal/xo/s_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/irifrance/gini/gen"
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/gen"
+	"github.com/operator-framework/gini/z"
 )
 
 func TestSRand3Cnf(t *testing.T) {

--- a/internal/xo/trail.go
+++ b/internal/xo/trail.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/z"
 )
 
 type late struct {

--- a/internal/xo/trail_test.go
+++ b/internal/xo/trail_test.go
@@ -7,8 +7,8 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/irifrance/gini/gen"
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/gen"
+	"github.com/operator-framework/gini/z"
 )
 
 func TestTrailBack(t *testing.T) {

--- a/internal/xo/vars.go
+++ b/internal/xo/vars.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/z"
 )
 
 type Vars struct {

--- a/internal/xo/vars_test.go
+++ b/internal/xo/vars_test.go
@@ -4,8 +4,9 @@
 package xo
 
 import (
-	"github.com/irifrance/gini/z"
 	"testing"
+
+	"github.com/operator-framework/gini/z"
 )
 
 var littleLits = [...]z.Lit{

--- a/internal/xo/watch.go
+++ b/internal/xo/watch.go
@@ -6,7 +6,7 @@ package xo
 import (
 	"fmt"
 
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/z"
 )
 
 // Watch holds other blocking literal, clause location (

--- a/internal/xo/watch_test.go
+++ b/internal/xo/watch_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/z"
 )
 
 func TestLocOverflow(t *testing.T) {

--- a/logic/aiger/aiger.go
+++ b/logic/aiger/aiger.go
@@ -11,8 +11,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/irifrance/gini/logic"
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/logic"
+	"github.com/operator-framework/gini/z"
 )
 
 // Errors related to IO and formatting

--- a/logic/aiger/aiger_test.go
+++ b/logic/aiger/aiger_test.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/irifrance/gini/logic"
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/logic"
+	"github.com/operator-framework/gini/z"
 	//	"fmt"
 )
 

--- a/logic/aiger/dfs.go
+++ b/logic/aiger/dfs.go
@@ -4,8 +4,8 @@
 package aiger
 
 import (
-	"github.com/irifrance/gini/logic"
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/logic"
+	"github.com/operator-framework/gini/z"
 )
 
 type sDfs struct {

--- a/logic/c.go
+++ b/logic/c.go
@@ -4,8 +4,8 @@
 package logic
 
 import (
-	"github.com/irifrance/gini/inter"
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/inter"
+	"github.com/operator-framework/gini/z"
 )
 
 // C represents a formula or combinational circuit.

--- a/logic/c_test.go
+++ b/logic/c_test.go
@@ -9,9 +9,9 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/irifrance/gini"
-	"github.com/irifrance/gini/logic"
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini"
+	"github.com/operator-framework/gini/logic"
+	"github.com/operator-framework/gini/z"
 )
 
 func TestCGrowStrash(t *testing.T) {

--- a/logic/card.go
+++ b/logic/card.go
@@ -4,7 +4,7 @@
 package logic
 
 import (
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/z"
 )
 
 // Card provides an interface for different implementations

--- a/logic/card_test.go
+++ b/logic/card_test.go
@@ -7,8 +7,8 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/irifrance/gini"
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini"
+	"github.com/operator-framework/gini/z"
 )
 
 func TestCardSort(t *testing.T) {

--- a/logic/roll.go
+++ b/logic/roll.go
@@ -3,7 +3,7 @@
 
 package logic
 
-import "github.com/irifrance/gini/z"
+import "github.com/operator-framework/gini/z"
 
 // Roll creates an unroller of sequential logic into
 // combinational logic.

--- a/logic/roll_test.go
+++ b/logic/roll_test.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/irifrance/gini"
-	"github.com/irifrance/gini/logic"
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini"
+	"github.com/operator-framework/gini/logic"
+	"github.com/operator-framework/gini/z"
 )
 
 func TestUnrollComb(t *testing.T) {

--- a/logic/s.go
+++ b/logic/s.go
@@ -3,7 +3,7 @@
 
 package logic
 
-import "github.com/irifrance/gini/z"
+import "github.com/operator-framework/gini/z"
 
 // S adds sequential elements to C, gini's combinational
 // logic representation.

--- a/logic/s_test.go
+++ b/logic/s_test.go
@@ -4,8 +4,9 @@
 package logic_test
 
 import (
-	"github.com/irifrance/gini/logic"
 	"testing"
+
+	"github.com/operator-framework/gini/logic"
 )
 
 func TestS(t *testing.T) {

--- a/s.go
+++ b/s.go
@@ -3,7 +3,7 @@
 
 package gini
 
-import "github.com/irifrance/gini/inter"
+import "github.com/operator-framework/gini/inter"
 
 // NewS creates a new solver, which is the Gini
 // implementation of inter.S.

--- a/sudoku_test.go
+++ b/sudoku_test.go
@@ -3,8 +3,8 @@ package gini_test
 import (
 	"fmt"
 
-	"github.com/irifrance/gini"
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini"
+	"github.com/operator-framework/gini/z"
 )
 
 func Example_sudoku() {

--- a/sv.go
+++ b/sv.go
@@ -6,8 +6,8 @@ package gini
 import (
 	"time"
 
-	"github.com/irifrance/gini/inter"
-	"github.com/irifrance/gini/z"
+	"github.com/operator-framework/gini/inter"
+	"github.com/operator-framework/gini/z"
 )
 
 type svWrap struct {


### PR DESCRIPTION
Update fork so that it can be directly imported
Replace package definition from github.com/irifrance/gini
to github.com/operator-framework/gini

Signed-off-by: kevinrizza <krizza@redhat.com>